### PR TITLE
fix(buckets): treat HU preflop SB as open (labels 2.2x/2.5x/3x) so sn…

### DIFF
--- a/backend/adapters/engines/pokerkit_adapter.py
+++ b/backend/adapters/engines/pokerkit_adapter.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 import hashlib, random
 
-# --- Lightweight state objects used ONLY by acceptance/bucket tests ---
+# --- Lightweight state objects used ONLY by the adapter acceptance/tests ---
 
 @dataclass
 class _TableSnap:
@@ -20,10 +20,14 @@ class _PlayerSnap:
     hole_cards: List[str]
 
 @dataclass
-class _ActionInfo:
-    bucket_label: Optional[str] = None
+class _LastAction:
+    seat: int
+    type: str
+    requested: Optional[int] = None
+    committed: Optional[int] = None
     snapped: Optional[bool] = None
-    committed: Optional[int] = None  # total target commitment for this action (bucket)
+    bucket_label: Optional[str] = None
+    allowed_buckets: Optional[List[str]] = None
 
 @dataclass
 class _GameSnap:
@@ -31,42 +35,42 @@ class _GameSnap:
     players: List[_PlayerSnap]
     street: str
     deck_seed: Optional[str]
-    last_action: Optional[_ActionInfo] = None
+    last_action: Optional[_LastAction] = None  # records snapping/meta
 
 # --- Adapter ---
 
 class PokerKitAdapter:
     """
-    Minimal adapter to satisfy TASK-03 + TASK-04:
-    - start_table(..., base_seed=None) -> store table config + base seed
-    - start_hand() -> rotate dealer, set SB/BB, determine first actor, deal deterministic hole cards
-    - next_actor() -> {"seat": int, "to_call": int, "allowed_buckets": [labels]}
-    - apply_action():
-        * HU preflop call/check logic (progress to flop)
-        * bet/raise: snap requested amount to nearest allowed bucket, record {snapped, bucket_label, committed}
-    - state() -> returns object with table, players[*].hole_cards, street, deck_seed, last_action
+    Minimal adapter w/ Task-04 polish & HU preflop-open labeling fix:
+      - HU preflop SB is treated as an OPEN (labels: 2.2x/2.5x/3.0x), even though to_call=BB-SB.
     """
     def __init__(self) -> None:
+        # table config
         self.seats: int = 0
         self.sb: int = 0
         self.bb: int = 0
         self.ante: int = 0
         self.base_seed: Optional[str] = None
+
+        # hand/runtime
         self.hand_id: int = 0
         self.button: int = -1
         self.sb_seat: Optional[int] = None
         self.bb_seat: Optional[int] = None
-        self._next_to_act: Optional[int] = None
         self._street: str = "preflop"
-        self._players_holes: List[List[str]] = []
         self._deck_seed: Optional[str] = None
 
-        # minimal betting state
+        # actor & betting
+        self._next_to_act: Optional[int] = None
         self._to_call_next: int = 0
         self._preflop_sb_called: bool = False
+        self._last_raise_size: int = 0  # increment amount for min-raise on this street
 
-        # last snapping info (for tests)
-        self._last_action: Optional[_ActionInfo] = None
+        # cards/state
+        self._players_holes: List[List[str]] = []
+
+        # meta for tests
+        self._last_action: Optional[_LastAction] = None
 
     # Signature must match tests: (seats, sb, bb, ante, stacks, base_seed=None)
     def start_table(
@@ -87,17 +91,23 @@ class PokerKitAdapter:
         self.bb = bb
         self.ante = ante
         self.base_seed = base_seed
+
+        # reset hand state
         self.hand_id = 0
         self.button = -1
         self.sb_seat = None
         self.bb_seat = None
-        self._next_to_act = None
         self._street = "preflop"
-        self._players_holes = []
         self._deck_seed = None
+
+        self._next_to_act = None
         self._to_call_next = 0
         self._preflop_sb_called = False
+        self._last_raise_size = 0
+        self._players_holes = []
         self._last_action = None
+
+    # --- helpers ---
 
     def _seeded_rng(self, seed_text: str) -> random.Random:
         h = hashlib.sha256(seed_text.encode("utf-8")).digest()
@@ -110,35 +120,81 @@ class PokerKitAdapter:
         rng.shuffle(deck)
         return deck
 
+    def _is_hu_preflop_open(self, to_call: int, seat: int) -> bool:
+        """HU preflop SB acts first; treat as an OPEN (label 2.2x/2.5x/3.0x) even though to_call==BB-SB."""
+        return (
+            self.seats == 2
+            and self._street == "preflop"
+            and seat == self.sb_seat
+            and to_call == max(0, self.bb - self.sb)
+        )
+
+    def _allowed_buckets_data(self, to_call: int, seat: int) -> List[Dict[str, Any]]:
+        """
+        Returns buckets as dicts: {"label": str, "target": int}
+        - HU preflop SB (open): 2.2x/2.5x/3x (total bet) + jam  (+ "call" still available)
+        - Generic open (to_call==0): 2.2x/2.5x/3x + jam
+        - Facing action (to_call>0): call, and raises {to_call + k*last_raise_size} with k in {2.5, 3.0}, + jam
+        """
+        buckets: List[Dict[str, Any]] = []
+
+        # call is always present when to_call > 0
+        if to_call > 0:
+            buckets.append({"label": "call", "target": to_call})
+
+        if self._is_hu_preflop_open(to_call, seat) or (to_call == 0 and self._street == "preflop"):
+            # OPEN labels
+            for mult in (2.2, 2.5, 3.0):
+                target = int(round(mult * self.bb))
+                buckets.append({"label": f"{mult:.1f}x", "target": max(target, self.bb)})
+        else:
+            # Facing action labels
+            if to_call > 0:
+                base = max(self._last_raise_size, self.bb)
+                for mult in (2.5, 3.0):
+                    target = to_call + int(round(mult * base))
+                    buckets.append({"label": f"{mult:.1f}xR", "target": target})
+
+        # Top of tree
+        buckets.append({"label": "jam", "target": 10**12})
+        buckets.sort(key=lambda b: b["target"])
+        return buckets
+
+    def _snap_to_bucket(self, requested_total: int, to_call: int, seat: int) -> Dict[str, Any]:
+        bks = self._allowed_buckets_data(to_call, seat)
+        best = min(bks, key=lambda b: (abs(b["target"] - requested_total), b["target"]))
+        return {
+            "target": best["target"],
+            "snapped": requested_total != best["target"],
+            "bucket_label": best["label"],
+            "allowed_buckets": [b["label"] for b in bks],
+        }
+
+    # --- hand lifecycle ---
+
     def start_hand(self) -> str:
         if self.seats <= 0:
             raise RuntimeError("call start_table first")
 
-        # Advance dealer
         self.hand_id += 1
         self.button = (self.button + 1) % self.seats
 
-        # Set blinds (BTN=SB in HU)
         self.sb_seat = self.button
         self.bb_seat = (self.button + 1) % self.seats
 
-        # Determine first actor (preflop)
         self._street = "preflop"
         if self.seats == 2:
-            # HU: SB acts first preflop, owes BB-SB
             self._next_to_act = self.sb_seat
             self._to_call_next = max(0, self.bb - self.sb)
         else:
-            # Multiway: UTG is seat left of BB
             self._next_to_act = (self.bb_seat + 1) % self.seats
-            self._to_call_next = 0  # tests don't require full multiway betting logic
+            self._to_call_next = 0
 
         self._preflop_sb_called = False
+        self._last_raise_size = self.bb
 
-        # Deterministic seed for this hand
         self._deck_seed = f"{self.base_seed}:{self.hand_id}" if self.base_seed is not None else None
 
-        # Deal deterministic hole cards
         rng = self._seeded_rng(self._deck_seed or f"default:{self.hand_id}")
         deck = self._new_shuffled_deck(rng)
         self._players_holes = []
@@ -148,147 +204,88 @@ class PokerKitAdapter:
         self._last_action = None
         return f"H{self.hand_id}"
 
-    # ---------- Buckets ----------
-
-    def _allowed_buckets_data(self, actor: int) -> List[Dict[str, Any]]:
-        """
-        Returns a list of bucket dicts: {"label": str, "commit": int}
-        commit = total target commitment for the action on this street.
-        """
-        # rough pot estimate for presentation (good enough for tests)
-        pot = self.sb + self.bb
-        to_call = max(0, self._to_call_next)
-        bb = self.bb
-
-        # For heads-up preflop exposure: offer common open/raise-to sizes (in bb)
-        buckets: List[Tuple[str, int]] = []
-        # Preflop opens/raises: 2.2x / 2.5x / 3x
-        for mult, label in [(2.2, "2.2x"), (2.5, "2.5x"), (3.0, "3x")]:
-            target = int(round(mult * bb))
-            if target > to_call:  # raising beyond call
-                buckets.append((label, target))
-
-        # Postflop: 33% / 66% / 100% pot (very rough; tests only check exposure)
-        for frac, label in [(0.33, "33%"), (0.66, "66%"), (1.00, "100%")]:
-            target = int(round(frac * pot))
-            if target > 0:
-                buckets.append((label, target))
-
-        # Jam is always available as top bucket (use a simple high cap)
-        buckets.append(("jam", 10**9))
-
-        # Deduplicate by label (keep first), sorted by commit ascending (except jam last)
-        uniq: Dict[str, int] = {}
-        for label, commit in buckets:
-            if label not in uniq:
-                uniq[label] = commit
-
-        # ensure 'jam' last
-        jam_commit = uniq.pop("jam")
-        items = sorted(uniq.items(), key=lambda kv: kv[1])
-        items.append(("jam", jam_commit))
-
-        return [{"label": lab, "commit": cm} for lab, cm in items]
-
-    # ---------- API ----------
+    # --- API ---
 
     def next_actor(self) -> Optional[Dict[str, Any]]:
         if self._next_to_act is None:
             return None
-        allowed = [b["label"] for b in self._allowed_buckets_data(self._next_to_act)]
-        return {"seat": int(self._next_to_act), "to_call": int(self._to_call_next), "allowed_buckets": allowed}
-
-    def _snap_to_bucket(self, requested: int, actor: int) -> Tuple[int, str, bool]:
-        """
-        Given a requested total commitment, snap to nearest allowed bucket.
-        Returns (snapped_commit, bucket_label, snapped_flag)
-        """
-        buckets = self._allowed_buckets_data(actor)
-        # choose nearest by absolute distance; tie -> smaller
-        best = None
-        for b in buckets:
-            commit = b["commit"]
-            dist = abs(commit - requested)
-            key = (dist, commit)  # commit ascending breaks ties to smaller
-            if best is None or key < best[0]:
-                best = ((dist, commit), b)
-        snapped_commit = best[1]["commit"]
-        label = best[1]["label"]
-        snapped_flag = (snapped_commit != requested)
-        return snapped_commit, label, snapped_flag
+        to_call = int(self._to_call_next)
+        seat = int(self._next_to_act)
+        buckets = self._allowed_buckets_data(to_call, seat)
+        return {
+            "seat": seat,
+            "to_call": to_call,
+            "allowed_buckets": [b["label"] for b in buckets],
+        }
 
     def apply_action(self, seat: int, action: str, amount: Optional[int] = None) -> None:
-        # Reset last action info each time
-        self._last_action = None
-
-        a = action.lower()
-
-        # ---- Snapping for bet/raise ----
-        if a in ("bet", "raise") and self._next_to_act is not None and seat == self._next_to_act:
-            # If no amount provided, pick the smallest bucket (first)
-            if amount is None:
-                first = self._allowed_buckets_data(seat)[0]
-                snapped_commit, label, snapped_flag = first["commit"], first["label"], False
-            else:
-                snapped_commit, label, snapped_flag = self._snap_to_bucket(int(amount), seat)
-
-            # Record for tests
-            self._last_action = _ActionInfo(bucket_label=label, snapped=snapped_flag, committed=snapped_commit)
-
-            # For simplicity in M0: advance turn order like a normal action
-            # (We keep the HU preflop progression rules below for call/check.)
-            # Move to next seat (BB after SB, SB after BB)
-            if self.seats == 2:
-                self._next_to_act = self.bb_seat if seat == self.sb_seat else self.sb_seat
-                # to_call stays simple here; acceptance tests don’t depend on full bet math
-                self._to_call_next = 0
+        if seat != self._next_to_act:
             return
 
-        # ---- Minimal HU preflop call/check logic to satisfy TASK-03 ----
-        if self.seats == 2 and self._street == "preflop":
-            # Enforce actor
-            if seat != self._next_to_act:
-                return  # ignore out-of-turn for these tests
+        action_l = (action or "").lower().strip()
+        to_call = int(self._to_call_next)
 
-            # SB acts first
-            if seat == self.sb_seat:
-                if self._to_call_next > 0 and a == "call":
-                    # SB matches BB
-                    self._preflop_sb_called = True
-                    # Next: BB, with 0 to call
+        if action_l == "check":
+            if to_call == 0:
+                if self.seats == 2 and self._street == "preflop" and seat == self.bb_seat and self._preflop_sb_called:
+                    self._street = "flop"
                     self._next_to_act = self.bb_seat
                     self._to_call_next = 0
-                elif self._to_call_next == 0 and a == "check":
-                    # Defensive fallback
-                    self._next_to_act = self.bb_seat
+                    self._last_raise_size = 0
+                else:
+                    self._next_to_act = self.sb_seat if seat == self.bb_seat else self.bb_seat
                     self._to_call_next = 0
-                return
+            else:
+                raise ValueError("illegal check facing to_call")
+            self._last_action = _LastAction(seat=seat, type="check")
+            return
 
-            # BB acts second
-            if seat == self.bb_seat:
-                if a == "check":
-                    # If SB called preflop, BB check closes the round -> flop
-                    if self._preflop_sb_called:
-                        self._street = "flop"
-                        # On flop, BB acts first in HU
-                        self._next_to_act = self.bb_seat
-                        self._to_call_next = 0
-                        self._preflop_sb_called = False
-                    else:
-                        # defensive fall-back
-                        self._next_to_act = self.sb_seat
-                        self._to_call_next = 0
-                elif a == "call":
-                    # Defensive: treat as check when to_call==0
-                    if self._to_call_next == 0 and self._preflop_sb_called:
-                        self._street = "flop"
-                        self._next_to_act = self.bb_seat
-                        self._to_call_next = 0
-                        self._preflop_sb_called = False
+        if action_l == "call":
+            if to_call <= 0:
+                return self.apply_action(seat, "check")
+            if self.seats == 2 and self._street == "preflop" and seat == self.sb_seat:
+                self._preflop_sb_called = True
+                self._next_to_act = self.bb_seat
+                self._to_call_next = 0
+                self._last_action = _LastAction(seat=seat, type="call", committed=to_call)
                 return
+            self._next_to_act = self.bb_seat if seat == self.sb_seat else self.sb_seat
+            self._to_call_next = 0
+            self._last_action = _LastAction(seat=seat, type="call", committed=to_call)
+            return
 
-        # Anything else: no-op (tests don't require full engine)
-        return None
+        if action_l in ("bet", "raise"):
+            if amount is None or not isinstance(amount, int):
+                raise ValueError("bet/raise requires integer 'amount' (total commitment)")
+
+            snap = self._snap_to_bucket(requested_total=amount, to_call=to_call, seat=seat)
+            committed = int(snap["target"])
+
+            min_raise_inc = max(self.bb, self._last_raise_size)
+            min_required = to_call + min_raise_inc if to_call > 0 else max(self.bb, committed)
+            if to_call > 0 and committed < min_required:
+                raise ValueError(f"min-raise not met: need ≥ {min_required}, got {committed}")
+
+            if to_call == 0 or self._is_hu_preflop_open(to_call, seat):
+                self._last_raise_size = max(committed, self.bb)
+            else:
+                self._last_raise_size = max(committed - to_call, self.bb)
+
+            self._next_to_act = self.bb_seat if seat == self.sb_seat else self.sb_seat
+            self._to_call_next = 0
+
+            self._last_action = _LastAction(
+                seat=seat,
+                type=action_l,
+                requested=amount,
+                committed=committed,
+                snapped=bool(snap["snapped"]),
+                bucket_label=snap["bucket_label"],
+                allowed_buckets=snap["allowed_buckets"],
+            )
+            return
+
+        raise ValueError(f"unknown action: {action}")
 
     def state(self) -> _GameSnap:
         tbl = _TableSnap(
@@ -300,7 +297,7 @@ class PokerKitAdapter:
             sb_seat=int(self.sb_seat) if self.sb_seat is not None else -1,
             bb_seat=int(self.bb_seat) if self.bb_seat is not None else -1,
         )
-        players = [_PlayerSnap(hole_cards=hc[:]) for hc in self._players_holes]  # copy
+        players = [_PlayerSnap(hole_cards=hc[:]) for hc in self._players_holes]
         return _GameSnap(
             table=tbl,
             players=players,


### PR DESCRIPTION
…apping reports '2.5x' not '2.5xR'

# PR Template (M0)

## What’s in this PR?
- [ ] Implements/updates TASK-XX from `docs/TASKS-M0.md`
- [ ] Adheres to `docs/M0-SPEC.md` scope (no solver/RL/multiway-solver)
- [ ] Updates relevant docs (API, Runbook, QA, etc.)

## Checklists

### Quality
- [ ] CI green (lint, type-check, tests)
- [ ] Added/updated unit tests and integration tests
- [ ] Updated QA checklist items where applicable
- [ ] Determinism preserved (seeded tests where relevant)

### Artifacts
- [ ] Attached the **slim .zip** build artifact (our source only, no vendored third-party code)
- [ ] Included lockfiles/requirements for reproducible installs

### Adapters & Third-Party
- [ ] I touched only **adapters** for third-party changes (no edits under `third_party/`)
- [ ] If ENGINE/EVALUATOR modes changed, I updated `docs/CONFIGURATION.md` and `docs/THIRD-PARTY-INTEGRATION.md`

### Scope Safety
- [ ] No solver calls or solver logic paths are active
- [ ] No RL
- [ ] No multiway solver approximations

## Screenshots / Demos (if UI)

## Notes for Reviewers