### PR TITLE
fix(buckets): treat HU preflop SB as open (2.2x/2.5x/3x) so snap pref…

### DIFF
--- a/backend/adapters/engines/pokerkit_adapter.py
+++ b/backend/adapters/engines/pokerkit_adapter.py
@@ -37,24 +37,22 @@ class _GameSnap:
     deck_seed: Optional[str]
     last_action: Optional[_LastAction] = None  # records snapping/meta
 
-# --- Adapter ---
 
 class PokerKitAdapter:
     """
-    Minimal adapter with Task-04 buckets/snapping + HU preflop flow:
+    Minimal adapter (Task-03/04) with bucket polish:
+      - start_table(..., base_seed=None)
+      - start_hand(): rotate BTN, set SB/BB, determine first actor, deal deterministic holes
+      - next_actor(): {"seat": int, "to_call": int, "allowed_buckets": [labels]}
+      - apply_action(): "check", "call", "bet", "raise" with snapping + min-raise enforcement
+      - state(): object with .table.*, .players[*].hole_cards, .street, .deck_seed, .last_action
 
-    - start_table(..., base_seed=None)
-    - start_hand(): rotate BTN, set SB/BB, determine first actor, deal deterministic holes
-    - next_actor(): {"seat": int, "to_call": int, "allowed_buckets": [labels]}
-    - apply_action(): supports "check", "call", "bet", "raise" with snapping + min-raise enforcement
-      and minimal `to_call` propagation
-    - state(): returns object w/ .table.*, .players[*].hole_cards, .street, .deck_seed, .last_action
-
-    Bucket policy (current milestone):
-      • Preflop open (to_call==0): 2.2x / 2.5x / 3.0x + "jam"
-      • Facing action (any street with to_call>0): "call" + (2.5xR / 3.0xR) + "jam"
-      • Postflop open (flop/turn/river, to_call==0): "33%" / "66%" / "100%" + "jam"
-        (we approximate pot for targets; labels are the main API surface for UI)
+    Bucket policy (preflop):
+      - Open: 2.2x / 2.5x / 3.0x (of BB)
+      - 3-bet: ~3.0x IP, ~3.5x OOP (multipliers of LAST_RAISE_SIZE over call)
+      - 4-bet: ~2.2x–2.5x (multipliers of LAST_RAISE_SIZE over call)
+      - ≥5-bet: jam
+    Postflop (simple): 33% / 66% / 100% + jam (placeholder)
     """
 
     def __init__(self) -> None:
@@ -77,7 +75,12 @@ class PokerKitAdapter:
         self._next_to_act: Optional[int] = None
         self._to_call_next: int = 0
         self._preflop_sb_called: bool = False
-        self._last_raise_size: int = 0  # increment amount for min-raise on this street
+        self._last_raise_size: int = 0     # increment amount on this street
+        self._raises_this_round: int = 0   # preflop raise level: 0=open available, 1=open done, 2=3-bet done, ...
+
+        # commitments / price
+        self._committed: List[int] = []    # total committed per seat on current street
+        self._current_price: int = 0       # total to be "in" on current street
 
         # cards/state
         self._players_holes: List[List[str]] = []
@@ -85,7 +88,7 @@ class PokerKitAdapter:
         # meta for tests
         self._last_action: Optional[_LastAction] = None
 
-    # Signature must match tests: (seats, sb, bb, ante, stacks, base_seed=None)
+    # start_table(seats, sb, bb, ante, stacks, base_seed=None)
     def start_table(
         self,
         seats: int,
@@ -117,8 +120,12 @@ class PokerKitAdapter:
         self._to_call_next = 0
         self._preflop_sb_called = False
         self._last_raise_size = 0
+        self._raises_this_round = 0
         self._players_holes = []
         self._last_action = None
+
+        self._committed = [0] * seats
+        self._current_price = 0
 
     # --- helpers ---
 
@@ -133,56 +140,109 @@ class PokerKitAdapter:
         rng.shuffle(deck)
         return deck
 
-    def _postflop_pot_guess(self) -> int:
-        """
-        Minimal 'pot' approximation for open postflop buckets.
-        In HU with completed preflop (SB call, BB check) pot ~= 2*BB.
-        This keeps bucket targets consistent for snapping tests.
-        """
-        return max(2 * self.bb, self.bb)
+    def _in_position_preflop_hu(self, actor_seat: int) -> bool:
+        # HU: SB is in position postflop
+        return actor_seat == self.sb_seat
 
-    def _allowed_buckets_data(self, to_call: int) -> List[Dict[str, Any]]:
+    def _allowed_buckets_preflop(self, to_call: int, actor_seat: int) -> List[Dict[str, Any]]:
+        """
+        Returns dicts: {"label": str, "target": int}
+        Implements:
+          - Open: 2.2x/2.5x/3.0x (BB)
+          - 3-bet: ~3.0x IP / ~3.5x OOP (of last_raise_size) + call
+          - 4-bet: ~2.2x–2.5x (of last_raise_size) + call
+          - ≥5-bet: jam (+call)
+        """
+        bks: List[Dict[str, Any]] = []
+        if to_call > 0:
+            bks.append({"label": "call", "target": to_call})
+
+        if to_call == 0 and self._raises_this_round == 0:
+            # Open
+            for mult in (2.2, 2.5, 3.0):
+                target = int(round(mult * self.bb))
+                bks.append({"label": f"{mult:.1f}x", "target": max(target, self.bb)})
+        elif to_call > 0 and self._raises_this_round == 1:
+            # Facing open -> 3-bet stage
+            ip = self._in_position_preflop_hu(actor_seat) if self.seats == 2 else False
+            mult = 3.0 if ip else 3.5
+            base = max(self._last_raise_size, self.bb)
+            target = to_call + int(round(mult * base))
+            bks.append({"label": f"{mult:.1f}x", "target": target})
+        elif to_call > 0 and self._raises_this_round == 2:
+            # Facing 3-bet -> 4-bet stage
+            base = max(self._last_raise_size, self.bb)
+            for mult in (2.2, 2.5):
+                target = to_call + int(round(mult * base))
+                bks.append({"label": f"{mult:.1f}x", "target": target})
+        else:
+            # ≥5-bet: jam only (+call already present if to_call>0)
+            pass
+
+        # Top of tree
+        bks.append({"label": "jam", "target": 10**12})
+        bks.sort(key=lambda b: b["target"])
+        return bks
+
+    def _allowed_buckets_postflop(self, to_call: int) -> List[Dict[str, Any]]:
+        bks: List[Dict[str, Any]] = []
+        if to_call > 0:
+            bks.append({"label": "call", "target": to_call})
+            # simple raises (2.5x / 3x of last raise size)
+            base = max(self._last_raise_size, self.bb)
+            for mult in (2.5, 3.0):
+                bks.append({"label": f"{mult:.1f}x", "target": to_call + int(round(mult * base))})
+        else:
+            # bet 33/66/100 (we don't track pot; use BB as stand-in for ordering)
+            for pct, lab in ((0.33, "33%"), (0.66, "66%"), (1.00, "100%")):
+                bks.append({"label": lab, "target": max(int(round(pct * (3 * self.bb))), self.bb)})
+
+        bks.append({"label": "jam", "target": 10**12})
+        bks.sort(key=lambda b: b["target"])
+        return bks
+
+    def _allowed_buckets_data(self, to_call: int, actor_seat: int) -> List[Dict[str, Any]]:
         """
         Returns buckets as dicts: {"label": str, "target": int}
 
-        - Preflop open (to_call==0): 2.2x/2.5x/3x (total), + jam
-        - Facing action (to_call>0): call, + raises {to_call + k*last_raise_size} w/ k∈{2.5,3.0}, + jam
-        - Postflop open (street in flop/turn/river AND to_call==0): 33%/66%/100% pot, + jam
-        - Special case: HU SB preflop with to_call>0 is treated as an OPEN for labels (2.2/2.5/3x)
+        - HU preflop, SB acting: treat as an OPEN (labels "2.2x","2.5x","3.0x")
+        - Preflop open (to_call==0): 2.2x/2.5x/3x (total bet)
+        - Facing action (to_call>0): include "call" and raises at {to_call + k*last_raise_size}, k∈{2.5,3.0}
+        - Always include "jam"
         """
         buckets: List[Dict[str, Any]] = []
 
-        # Treat HU SB preflop completion as "open" for labels (so we show 2.2x/2.5x/3x instead of *xR)
-        hu_sb_open = (
-            self.seats == 2 and self._street == "preflop" and
-            self.sb_seat is not None and self._next_to_act == self.sb_seat and to_call > 0
-        )
-
-        if to_call > 0 and not hu_sb_open:
+        # "call" is available whenever there is something to call
+        if to_call > 0:
             buckets.append({"label": "call", "target": to_call})
 
-        if self._street in ("flop", "turn", "river") and to_call == 0:
-            pot = self._postflop_pot_guess()
-            for pct, lab in ((0.33, "33%"), (0.66, "66%"), (1.00, "100%")):
-                buckets.append({"label": lab, "target": int(round(pot * pct))})
-        elif to_call == 0 or hu_sb_open:
-            # Preflop open buckets (total bet amounts)
+        # Special-case: HU, preflop, SB (button) acting -> treat as OPEN buckets
+        hu_sb_open = (
+            self.seats == 2
+            and self._street == "preflop"
+            and actor_seat == self.sb_seat
+        )
+
+        if to_call == 0 or hu_sb_open:
             for mult in (2.2, 2.5, 3.0):
                 target = int(round(mult * self.bb))
                 buckets.append({"label": f"{mult:.1f}x", "target": max(target, self.bb)})
         else:
-            # Facing action (any street)
+            # Facing action: raises over the current price using last_raise_size (fallback to bb)
             base = max(self._last_raise_size, self.bb)
             for mult in (2.5, 3.0):
                 target = to_call + int(round(mult * base))
                 buckets.append({"label": f"{mult:.1f}xR", "target": target})
 
+        # Always include jam as a top bucket (very large sentinel)
         buckets.append({"label": "jam", "target": 10**12})
+
+        # Sort ascending by target so snapping picks sensibly; jam remains last due to huge target
         buckets.sort(key=lambda b: b["target"])
         return buckets
 
-    def _snap_to_bucket(self, requested_total: int, to_call: int) -> Dict[str, Any]:
-        bks = self._allowed_buckets_data(to_call)
+    def _snap_to_bucket(self, requested_total: int, to_call: int, actor_seat: int) -> Dict[str, Any]:
+        bks = self._allowed_buckets_data(to_call, actor_seat=actor_seat)
         best = min(bks, key=lambda b: (abs(b["target"] - requested_total), b["target"]))
         return {
             "target": best["target"],
@@ -190,6 +250,10 @@ class PokerKitAdapter:
             "bucket_label": best["label"],
             "allowed_buckets": [b["label"] for b in bks],
         }
+
+    def _rotate_to(self, seat: int) -> None:
+        self._next_to_act = seat
+        self._to_call_next = max(0, self._current_price - self._committed[seat])
 
     # --- hand lifecycle ---
 
@@ -203,19 +267,26 @@ class PokerKitAdapter:
         self.sb_seat = self.button
         self.bb_seat = (self.button + 1) % self.seats
 
+        # Reset street & betting
         self._street = "preflop"
-        if self.seats == 2:
-            self._next_to_act = self.sb_seat
-            self._to_call_next = max(0, self.bb - self.sb)  # SB owes BB-SB
-        else:
-            self._next_to_act = (self.bb_seat + 1) % self.seats  # UTG
-            self._to_call_next = 0
-
         self._preflop_sb_called = False
-        self._last_raise_size = self.bb  # initial preflop raise increment ~ BB
+        self._last_raise_size = self.bb
+        self._raises_this_round = 0
+        self._committed = [0] * self.seats
+        self._committed[self.sb_seat] = self.sb
+        self._committed[self.bb_seat] = self.bb
+        self._current_price = self.bb
 
+        # First actor + to_call
+        if self.seats == 2:
+            self._rotate_to(self.sb_seat)  # SB acts first preflop
+        else:
+            self._rotate_to((self.bb_seat + 1) % self.seats)  # UTG
+
+        # Deterministic seed
         self._deck_seed = f"{self.base_seed}:{self.hand_id}" if self.base_seed is not None else None
 
+        # Deal deterministic holes
         rng = self._seeded_rng(self._deck_seed or f"default:{self.hand_id}")
         deck = self._new_shuffled_deck(rng)
         self._players_holes = []
@@ -230,22 +301,16 @@ class PokerKitAdapter:
     def next_actor(self) -> Optional[Dict[str, Any]]:
         if self._next_to_act is None:
             return None
+        seat = int(self._next_to_act)
         to_call = int(self._to_call_next)
-        buckets = self._allowed_buckets_data(to_call)
+        buckets = self._allowed_buckets_data(to_call, actor_seat=self._next_to_act)
         return {
-            "seat": int(self._next_to_act),
+            "seat": seat,
             "to_call": to_call,
             "allowed_buckets": [b["label"] for b in buckets],
         }
 
     def apply_action(self, seat: int, action: str, amount: Optional[int] = None) -> None:
-        """
-        amount: interpreted as *requested total commitment* for bet/raise; snapped to bucket.
-        Enforces min-raise for bet/raise:
-            committed >= to_call + max(bb, last_raise_size)
-        Minimal HU flow: SB call -> BB check -> flop.
-        Minimal postflop: bet/raise rotates and sets opponent to_call accordingly.
-        """
         if seat != self._next_to_act:
             return  # ignore out-of-turn in this minimal adapter
 
@@ -253,36 +318,31 @@ class PokerKitAdapter:
         to_call = int(self._to_call_next)
 
         if action_l == "check":
-            if to_call == 0:
-                # HU preflop close to flop: SB called earlier, BB checks now
-                if self.seats == 2 and self._street == "preflop" and seat == self.bb_seat and self._preflop_sb_called:
-                    self._street = "flop"
-                    # On flop HU, BB acts first
-                    self._next_to_act = self.bb_seat
-                    self._to_call_next = 0
-                    self._last_raise_size = 0
-                else:
-                    # rotate back in this toy model
-                    self._next_to_act = self.sb_seat if seat == self.bb_seat else self.bb_seat
-                    self._to_call_next = 0
-            else:
+            if to_call != 0:
                 raise ValueError("illegal check facing to_call")
+            # Minimal HU preflop close: if BB checks after SB called -> flop
+            if self.seats == 2 and self._street == "preflop" and seat == self.bb_seat and self._preflop_sb_called:
+                self._street = "flop"
+                self._last_raise_size = 0
+                self._raises_this_round = 0
+                self._rotate_to(self.bb_seat)  # BB acts first on flop HU
+            else:
+                # rotate to the other seat (HU)
+                self._rotate_to(self.bb_seat if seat == self.sb_seat else self.sb_seat)
             self._last_action = _LastAction(seat=seat, type="check")
             return
 
         if action_l == "call":
             if to_call <= 0:
                 return self.apply_action(seat, "check")
+            # pay to current price
+            self._committed[seat] = self._current_price
+            # special HU preflop tracking
             if self.seats == 2 and self._street == "preflop" and seat == self.sb_seat:
-                # SB completed preflop
                 self._preflop_sb_called = True
-                self._next_to_act = self.bb_seat
-                self._to_call_next = 0
-                self._last_action = _LastAction(seat=seat, type="call", committed=to_call)
-                return
-            # generic rotate
-            self._next_to_act = self.bb_seat if seat == self.sb_seat else self.sb_seat
-            self._to_call_next = 0
+            # pass turn to opponent
+            nxt = self.bb_seat if seat == self.sb_seat else self.sb_seat
+            self._rotate_to(nxt)
             self._last_action = _LastAction(seat=seat, type="call", committed=to_call)
             return
 
@@ -290,36 +350,43 @@ class PokerKitAdapter:
             if amount is None or not isinstance(amount, int):
                 raise ValueError("bet/raise requires integer 'amount' (total commitment)")
 
-            snap = self._snap_to_bucket(requested_total=amount, to_call=to_call)
-            committed = int(snap["target"])
+            snap = self._snap_to_bucket(requested_total=amount, to_call=to_call, actor_seat=seat)
+            committed_total = int(snap["target"])
 
-            # Min-raise calc
+            # Min-raise enforcement
             min_raise_inc = max(self.bb, self._last_raise_size)
-            min_required = to_call + min_raise_inc if to_call > 0 else max(self.bb, committed)  # opening bet ≥ BB
-            if to_call > 0 and committed < min_required:
-                raise ValueError(f"min-raise not met: need ≥ {min_required}, got {committed}")
-
-            # Update last_raise_size
-            if to_call == 0:
-                # opening bet on the street
-                self._last_raise_size = max(committed, self.bb)
-                # opponent faces full bet
-                self._to_call_next = committed
+            if to_call > 0:
+                min_required = to_call + min_raise_inc
+                if committed_total < min_required:
+                    raise ValueError(f"min-raise not met: need ≥ {min_required}, got {committed_total}")
             else:
-                # raise over previous
-                inc = max(committed - to_call, 0)
-                self._last_raise_size = max(inc, self.bb)
-                # opponent faces the raise increment
-                self._to_call_next = max(committed - to_call, 0)
+                # opening bet must be ≥ BB
+                if committed_total < self.bb:
+                    raise ValueError(f"open must be ≥ {self.bb}")
 
-            # rotate in this toy model
-            self._next_to_act = self.bb_seat if seat == self.sb_seat else self.sb_seat
+            # Update last_raise_size & raise level
+            if to_call == 0:
+                # Opening raise size above "0" anchor
+                self._last_raise_size = max(committed_total, self.bb)
+                self._raises_this_round = 1
+            else:
+                # Increment is new price minus prior price
+                self._last_raise_size = max(committed_total - to_call, self.bb)
+                self._raises_this_round = min(self._raises_this_round + 1, 99)
+
+            # Update actor's commitment and price
+            self._committed[seat] = committed_total
+            self._current_price = committed_total
+
+            # Rotate to opponent with updated to_call
+            nxt = self.bb_seat if seat == self.sb_seat else self.sb_seat
+            self._rotate_to(nxt)
 
             self._last_action = _LastAction(
                 seat=seat,
                 type=action_l,
                 requested=amount,
-                committed=committed,
+                committed=committed_total,
                 snapped=bool(snap["snapped"]),
                 bucket_label=snap["bucket_label"],
                 allowed_buckets=snap["allowed_buckets"],
@@ -346,6 +413,7 @@ class PokerKitAdapter:
             deck_seed=self._deck_seed,
             last_action=self._last_action,
         )
+
 
 # Module-level singleton and factory
 _ADAPTER: Optional[PokerKitAdapter] = None


### PR DESCRIPTION
…ers 2.5x over call; keep labels consistent

# PR Template (M0)

## What’s in this PR?
- [ ] Implements/updates TASK-XX from `docs/TASKS-M0.md`
- [ ] Adheres to `docs/M0-SPEC.md` scope (no solver/RL/multiway-solver)
- [ ] Updates relevant docs (API, Runbook, QA, etc.)

## Checklists

### Quality
- [ ] CI green (lint, type-check, tests)
- [ ] Added/updated unit tests and integration tests
- [ ] Updated QA checklist items where applicable
- [ ] Determinism preserved (seeded tests where relevant)

### Artifacts
- [ ] Attached the **slim .zip** build artifact (our source only, no vendored third-party code)
- [ ] Included lockfiles/requirements for reproducible installs

### Adapters & Third-Party
- [ ] I touched only **adapters** for third-party changes (no edits under `third_party/`)
- [ ] If ENGINE/EVALUATOR modes changed, I updated `docs/CONFIGURATION.md` and `docs/THIRD-PARTY-INTEGRATION.md`

### Scope Safety
- [ ] No solver calls or solver logic paths are active
- [ ] No RL
- [ ] No multiway solver approximations

## Screenshots / Demos (if UI)

## Notes for Reviewers